### PR TITLE
Add color detection for hex colors from Int values

### DIFF
--- a/XcodeColorSense/Matcher/HexMatcher.swift
+++ b/XcodeColorSense/Matcher/HexMatcher.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-public struct HexMatcher: Matcher {
+public struct HexStringMatcher: Matcher {
 
   func check(line: String, selectedText: String) -> (color: NSColor, range: NSRange)? {
     let pattern = "\"#?[A-Fa-f0-9]{6}\""
@@ -21,4 +21,21 @@ public struct HexMatcher: Matcher {
 
     return (color: color, range: range)
   }
+}
+
+public struct HexIntMatcher: Matcher {
+    
+    func check(line: String, selectedText: String) -> (color: NSColor, range: NSRange)? {
+        guard line.contains("UIColor") || line.contains("NSColor") else { return nil }
+        
+        let pattern = "0x[A-Fa-f0-9]{6}"
+        
+        guard let range = Regex.check(line, pattern: pattern)
+            else { return nil }
+        
+        let text = (line as NSString).substringWithRange(range).replace("0x", with: "")
+        let color = NSColor.hex(text)
+        
+        return (color: color, range: range)
+    }
 }

--- a/XcodeColorSense/XcodeColorSense.swift
+++ b/XcodeColorSense/XcodeColorSense.swift
@@ -16,7 +16,8 @@ class XcodeColorSense: NSObject {
   var textView: NSTextView?
   let previewView = PreviewView(frame: CGRect(origin: CGPointZero, size: CGSize(width: 60, height: 40)))
   let matchers: [Matcher] = [
-    HexMatcher(),
+    HexStringMatcher(),
+    HexIntMatcher(),
     PresetMatcher(),
     RGBAMatcher(),
   ]


### PR DESCRIPTION
Just another simple matcher for matching colors defines like this

```
UIColor(hex: 0x5856d6)
```

Of course, I can create this using this UIColor extention

```
extension UIColor {

    convenience init(red: Int, green: Int, blue: Int) {
        assert(red >= 0 && red <= 255, "Invalid red component")
        assert(green >= 0 && green <= 255, "Invalid green component")
        assert(blue >= 0 && blue <= 255, "Invalid blue component")

        self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
    }

    convenience init(hex: Int) {
        self.init(red:(hex >> 16) & 0xff, green:(hex >> 8) & 0xff, blue:hex & 0xff)
    }
}
```
